### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Ejb503/systemprompt-mcp-notion/badge.svg?branch=main)](https://coveralls.io/github/Ejb503/systemprompt-mcp-notion?branch=main)
 [![Twitter Follow](https://img.shields.io/twitter/follow/tyingshoelaces_?style=social)](https://twitter.com/tyingshoelaces_)
 [![Discord](https://img.shields.io/discord/1255160891062620252?color=7289da&label=discord)](https://discord.com/invite/wkAbSuPWpr)
+[![smithery badge](https://smithery.ai/badge/systemprompt-mcp-notion)](https://smithery.ai/server/systemprompt-mcp-notion)
 
 [Website](https://systemprompt.io) | [Documentation](https://systemprompt.io/documentation) | [Blog](https://tyingshoelaces.com)
 
@@ -68,6 +69,14 @@ Before using this server, you'll need:
 ## Quick Start
 
 1. **Installation**
+
+   ### Installing via Smithery
+
+   To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/systemprompt-mcp-notion):
+
+   ```bash
+   npx -y @smithery/cli install systemprompt-mcp-notion --client claude
+   ```
 
    ```bash
    npm install systemprompt-mcp-notion


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install systemprompt-mcp-notion for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/systemprompt-mcp-notion

Let me know if any tweaks have to be made!