### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A high-performance Model Context Protocol (MCP) server that seamlessly integrate
 
 A compatible MCP client is available [here](https://github.com/Ejb503/multimodal-mcp-client). Complicated AI usage is managed by sampling and LLMs.
 
+<a href="https://glama.ai/mcp/servers/xe6grtrr0k"><img width="380" height="200" src="https://glama.ai/mcp/servers/xe6grtrr0k/badge" alt="SystemPrompt Notion Server MCP server" /></a>
+
 ## Server Capabilities
 
 const serverCapabilities: { capabilities: ServerCapabilities } = {


### PR DESCRIPTION
This PR adds a badge for the [SystemPrompt MCP Notion Server](https://glama.ai/mcp/servers/xe6grtrr0k) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xe6grtrr0k"><img width="380" height="200" src="https://glama.ai/mcp/servers/xe6grtrr0k/badge" alt="SystemPrompt Notion Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.