### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Use an official Node.js image as the base image
+FROM node:18-alpine AS builder
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the TypeScript code
+RUN npm run build
+
+# Use a lightweight Node.js image to reduce the final size
+FROM node:18-alpine AS release
+
+# Set the working directory in the release image
+WORKDIR /app
+
+# Copy the build output and node_modules from the builder stage
+COPY --from=builder /app/build /app/build
+COPY --from=builder /app/node_modules /app/node_modules
+
+# Set environment variables required by the application
+ENV NODE_ENV=production
+ENV SYSTEMPROMPT_API_KEY=your_systemprompt_api_key
+ENV NOTION_API_KEY=your_notion_integration_token
+
+# Set the command to run the application
+ENTRYPOINT ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Ejb503/systemprompt-mcp-notion/badge.svg?branch=main)](https://coveralls.io/github/Ejb503/systemprompt-mcp-notion?branch=main)
 [![Twitter Follow](https://img.shields.io/twitter/follow/tyingshoelaces_?style=social)](https://twitter.com/tyingshoelaces_)
 [![Discord](https://img.shields.io/discord/1255160891062620252?color=7289da&label=discord)](https://discord.com/invite/wkAbSuPWpr)
-[![smithery badge](https://smithery.ai/badge/systemprompt-mcp-notion)](https://smithery.ai/protocol/systemprompt-mcp-notion)
+[![smithery badge](https://smithery.ai/badge/systemprompt-mcp-notion)](https://smithery.ai/server/systemprompt-mcp-notion)
 
 [Website](https://systemprompt.io) | [Documentation](https://systemprompt.io/documentation) | [Blog](https://tyingshoelaces.com)
 
@@ -76,10 +76,10 @@ Before using this server, you'll need:
 
    ### Installing via Smithery
 
-   To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/systemprompt-mcp-notion):
+   To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/systemprompt-mcp-notion):
 
    ```bash
-   npx @smithery/cli install 016f8b66-26ca-4c12-b1c5-94f04ee3b17e --client claude
+   npx @smithery/cli install systemprompt-mcp-notion --client claude
    ```
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Ejb503/systemprompt-mcp-notion/badge.svg?branch=main)](https://coveralls.io/github/Ejb503/systemprompt-mcp-notion?branch=main)
 [![Twitter Follow](https://img.shields.io/twitter/follow/tyingshoelaces_?style=social)](https://twitter.com/tyingshoelaces_)
 [![Discord](https://img.shields.io/discord/1255160891062620252?color=7289da&label=discord)](https://discord.com/invite/wkAbSuPWpr)
-[![smithery badge](https://smithery.ai/badge/systemprompt-mcp-notion)](https://smithery.ai/server/systemprompt-mcp-notion)
+[![smithery badge](https://smithery.ai/badge/systemprompt-mcp-notion)](https://smithery.ai/protocol/systemprompt-mcp-notion)
 
 [Website](https://systemprompt.io) | [Documentation](https://systemprompt.io/documentation) | [Blog](https://tyingshoelaces.com)
 
@@ -76,10 +76,10 @@ Before using this server, you'll need:
 
    ### Installing via Smithery
 
-   To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/systemprompt-mcp-notion):
+   To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/systemprompt-mcp-notion):
 
    ```bash
-   npx -y @smithery/cli install systemprompt-mcp-notion --client claude
+   npx @smithery/cli install 016f8b66-26ca-4c12-b1c5-94f04ee3b17e --client claude
    ```
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Before using this server, you'll need:
    To install systemprompt-mcp-notion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/systemprompt-mcp-notion):
 
    ```bash
-   npx @smithery/cli install systemprompt-mcp-notion --client claude
+   npx -y @smithery/cli install systemprompt-mcp-notion --client claude
    ```
 
    ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - systempromptApiKey
+      - notionApiKey
+    properties:
+      systempromptApiKey:
+        type: string
+        description: Your SystemPrompt API key.
+      notionApiKey:
+        type: string
+        description: Your Notion integration token.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['build/index.js'], env: { SYSTEMPROMPT_API_KEY: config.systempromptApiKey, NOTION_API_KEY: config.notionApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/systemprompt-mcp-notion) and claiming it.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂